### PR TITLE
Add :history to metadata as a list of transformations applied to the data, for provenance tracking.

### DIFF
--- a/src/ARPESData.jl
+++ b/src/ARPESData.jl
@@ -30,6 +30,7 @@ Container for ARPES data.
     * `:analyzer_configuration` - one of the `AnalyzerConfiguration` types (TypeI, TypeII, etc.)
     * `:hv` - the photon energy in eV (should match the :hv in the data array metadata)
       (Note: in future, consider to use :hν instead of :hv)
+    * `:history` - a list of transformations applied to the data, for provenance tracking.
     * `:β`: used for momentum conversion. if the dims include psi, angle `β` is not required.
     * `:ξ`: used for momentum conversion.
     * `:χ`: used for momentum conversion.

--- a/src/ARPESData.jl
+++ b/src/ARPESData.jl
@@ -99,9 +99,16 @@ function ARPESData(
     energy_def::EnergyDefinition = BindingEnergy,
     additional_metadata::AbstractDict = Dict(),
 )
-    extra_metadata =
-        Dict(:analyzer_configuration => analyzer_config, :intensity_unit => intensity_unit)
-    new_metadata = merge(Dict(metadata(data)), extra_metadata, Dict(additional_metadata))
+    default_metadata_for_arpesdata = Dict(
+        :analyzer_configuration => analyzer_config,
+        :intensity_unit => intensity_unit,
+        :history => Union{String,Pair}[],
+    )
+    new_metadata = merge(
+        Dict(metadata(data)),
+        default_metadata_for_arpesdata,
+        Dict(additional_metadata),
+    )
 
     # Add :energy_definition to the metadata of the eV dimension
     new_dims = map(dims(data)) do d

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -181,7 +181,10 @@ end
     spd_standard = test_spd_standard()
     # Rebin along phi with new edges
     rebin_spd = rebin(spd_standard, :phi, 10)
+    rebin_spd_by_bins = rebin(spd_standard, :phi, Bins(10))
     @test size(rebin_spd) == (10, 601)
-    @test rebin_spd == rebin(spd_standard, :phi, Bins(10))
+    @test parent(rebin_spd) == parent(rebin(spd_standard, :phi, Bins(10)))
     @test ARPES._is_equal_spacing(lookup(rebin_spd, :phi))
+    @test metadata(rebin_spd)[:history][end] == "rebin by 10 along phi"
+    @test metadata(rebin_spd)[:history][end] == "rebin by Bins(identity, 10) along phi"
 end


### PR DESCRIPTION
Add Dict(:histroy => Union{String, Pair}[]) to the metadata of ARPES.
Add write_provenance functionality to 
- [ ] Filter
- [ ] Derivative and it's related.
- [ ] rebin
- [ ] shift

Need to consider
- [x] cat_arpes (What info should be added?)