### PR TITLE
stitch_along and improve seam splitting logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] — 2026-XX-XX
+
+### Added
+
+- `stitch_along`
+  - Stitch two `AbstractDimArray`s together along a specified dimension.
+  - Handles overlapping regions: `seam_ratio` controls the split point within the overlap (0–1; `nothing` concatenates directly without splitting).
+  - `gain_a` applies a multiplicative scale to the first array before concatenating.
+  - Result is always sorted along the stitched dimension.
+
 ## [0.2.0] — 2026-04-08
 
 ### Breaking change (Removed)

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ARPES"
 uuid = "3764e38b-e87f-453d-b456-dc646f8e1bb8"
-version = "0.2.0"
+version = "0.2.1dev"
 authors = ["Ryuichi Arafune"]
 
 [deps]

--- a/src/ARPES.jl
+++ b/src/ARPES.jl
@@ -13,6 +13,7 @@ export merge_consensus
 export kx, ky, kz, phi, psi, eV, detector_ch, ch2, delay, spin
 export CPS, Counts
 export ARPESData
+include("./stitch.jl")
 include("./pumpprobe.jl")
 include("./transform.jl")
 

--- a/src/stitch.jl
+++ b/src/stitch.jl
@@ -1,0 +1,92 @@
+using DimensionalData
+using DimensionalData: Dimension
+using DimensionalData: basetypeof
+using DimensionalData.Lookups
+using DimensionalData.Dimensions: label
+
+export stitch_along
+
+"""
+    stitch_along(A, B, dim; occupation_ratio=nothing, enhance_a=1.0)
+
+Stitch two `AbstractDimArray`s together along `dim`.
+
+- `occupation_ratio`: fraction of the overlap region assigned to the left array.
+  `nothing` (default) means no overlap splitting — arrays are concatenated directly.
+- `enhance_a`: multiplicative scale factor applied to `A` before concatenating.
+"""
+function stitch_along(
+    A::AbstractDimArray,
+    B::AbstractDimArray,
+    dim::Union{Dimension,Symbol},
+    occupation_ratio::Union{Real,Nothing},
+    enhance_a::Real,
+)
+    @assert name(dims(A)) == name(dims(B))
+    otherdims_A = otherdims(A, dim)
+    otherdims_B = otherdims(B, dim)
+    @assert otherdims_A == otherdims_B
+    extrema_A = extrema(lookup(A, dim))
+    extrema_B = extrema(lookup(B, dim))
+    @debug "extrema_A" extrema_A
+    @debug "extrema_B" extrema_B
+    if isnothing(occupation_ratio) ||
+       (extrema_A[2] < extrema_B[1]) ||
+       (extrema_B[2] < extrema_A[1])
+        @debug "concatenating"
+        return _cat_and_sort(A, B, dim, enhance_a)
+    end
+    @assert 0.0 <= occupation_ratio <= 1.0 "occupation_ratio must be between 0 and 1"
+    if extrema_A[1] < extrema_B[1]
+        left, right = A, B
+    elseif extrema_B[1] < extrema_A[1]
+        left, right = B, A
+    else
+        error(
+            "The arrays have the same extrema, cannot decide which one is left and which one is right",
+        )
+    end
+    seam_dim =
+        (maximum(lookup(left, name(dim))) - minimum(lookup(right, name(dim)))) *
+        occupation_ratio + minimum(lookup(right, name(dim)))
+    @debug "seam_dim" seam_dim
+    left_part = left[Dim{name(dim)}(At(<(seam_dim)))]
+    right_part = right[Dim{name(dim)}(At(>=(seam_dim)))]
+    return _cat_and_sort(left_part, right_part, dim, enhance_a)
+end
+
+
+
+stitch_along(
+    A::AbstractDimArray,
+    B::AbstractDimArray,
+    dim::Union{Dimension,Symbol};
+    occupation_ratio::Union{Real,Nothing} = nothing,
+    enhance_a::Real = 1.0,
+) = stitch_along(A, B, dim, occupation_ratio, enhance_a)
+
+function _cat_and_sort(
+    A::AbstractDimArray,
+    B::AbstractDimArray,
+    dim::Union{Dimension,Symbol},
+    enhance_a,
+)
+    along_dim = dims(A, dim)
+    along_dim_idx = dimnum(A, dim)
+    cat_dim = vcat(lookup(A, along_dim), lookup(B, along_dim))
+    new_along_dim = rebuild(
+        along_dim,
+        Sampled(cat_dim, ForwardOrdered(), Irregular(), Points(), metadata(along_dim)),
+    )
+    @debug "cat_dim" cat_dim
+    @debug "new_along_dim" new_along_dim
+    cat_data = cat(parent(A) .* enhance_a, parent(B), dims = along_dim_idx)
+    @debug "size_of cat_data" size(cat_data)
+    stitch_dimArray = rebuild(
+        A;
+        data = cat_data,
+        dims = Base.setindex(dims(A), new_along_dim, along_dim_idx),
+    )
+    p = sortperm(lookup(stitch_dimArray, new_along_dim))
+    return stitch_dimArray[Dim{name(new_along_dim)}(p)]
+end

--- a/src/stitch.jl
+++ b/src/stitch.jl
@@ -14,6 +14,10 @@ Stitch two `AbstractDimArray`s together along `dim`.
 - `seam_ratio`: fraction of the overlap region assigned to the left array.
   `nothing` (default) means no overlap splitting — arrays are concatenated directly.
 - `gain_a`: multiplicative scale factor applied to `A` before concatenating.
+
+# Notes
+
+- ARPESPlots.jl provides a convenient interface for this function, as `stitch_ui`.
 """
 function stitch_along(
     A::AbstractDimArray,

--- a/src/stitch.jl
+++ b/src/stitch.jl
@@ -59,8 +59,6 @@ function stitch_along(
     return _cat_and_sort(left_part, right_part, dim, gain_a)
 end
 
-
-
 stitch_along(
     A::AbstractDimArray,
     B::AbstractDimArray,

--- a/src/stitch.jl
+++ b/src/stitch.jl
@@ -7,20 +7,20 @@ using DimensionalData.Dimensions: label
 export stitch_along
 
 """
-    stitch_along(A, B, dim; occupation_ratio=nothing, enhance_a=1.0)
+    stitch_along(A, B, dim; seam_ratio=nothing, gain_a=1.0)
 
 Stitch two `AbstractDimArray`s together along `dim`.
 
-- `occupation_ratio`: fraction of the overlap region assigned to the left array.
+- `seam_ratio`: fraction of the overlap region assigned to the left array.
   `nothing` (default) means no overlap splitting — arrays are concatenated directly.
-- `enhance_a`: multiplicative scale factor applied to `A` before concatenating.
+- `gain_a`: multiplicative scale factor applied to `A` before concatenating.
 """
 function stitch_along(
     A::AbstractDimArray,
     B::AbstractDimArray,
     dim::Union{Dimension,Symbol},
-    occupation_ratio::Union{Real,Nothing},
-    enhance_a::Real,
+    seam_ratio::Union{Real,Nothing},
+    gain_a::Real,
 )
     @assert name(dims(A)) == name(dims(B))
     otherdims_A = otherdims(A, dim)
@@ -30,13 +30,13 @@ function stitch_along(
     extrema_B = extrema(lookup(B, dim))
     @debug "extrema_A" extrema_A
     @debug "extrema_B" extrema_B
-    if isnothing(occupation_ratio) ||
+    if isnothing(seam_ratio) ||
        (extrema_A[2] < extrema_B[1]) ||
        (extrema_B[2] < extrema_A[1])
         @debug "concatenating"
-        return _cat_and_sort(A, B, dim, enhance_a)
+        return _cat_and_sort(A, B, dim, gain_a)
     end
-    @assert 0.0 <= occupation_ratio <= 1.0 "occupation_ratio must be between 0 and 1"
+    @assert 0.0 <= seam_ratio <= 1.0 "seam_ratio must be between 0 and 1"
     if extrema_A[1] < extrema_B[1]
         left, right = A, B
     elseif extrema_B[1] < extrema_A[1]
@@ -48,11 +48,11 @@ function stitch_along(
     end
     seam_dim =
         (maximum(lookup(left, name(dim))) - minimum(lookup(right, name(dim)))) *
-        occupation_ratio + minimum(lookup(right, name(dim)))
+        seam_ratio + minimum(lookup(right, name(dim)))
     @debug "seam_dim" seam_dim
-    left_part = left[Dim{name(dim)}(At(<(seam_dim)))]
-    right_part = right[Dim{name(dim)}(At(>=(seam_dim)))]
-    return _cat_and_sort(left_part, right_part, dim, enhance_a)
+    left_part = left[Dim{name(dim)}(Where(<(seam_dim)))]
+    right_part = right[Dim{name(dim)}(Where(>=(seam_dim)))]
+    return _cat_and_sort(left_part, right_part, dim, gain_a)
 end
 
 
@@ -61,15 +61,15 @@ stitch_along(
     A::AbstractDimArray,
     B::AbstractDimArray,
     dim::Union{Dimension,Symbol};
-    occupation_ratio::Union{Real,Nothing} = nothing,
-    enhance_a::Real = 1.0,
-) = stitch_along(A, B, dim, occupation_ratio, enhance_a)
+    seam_ratio::Union{Real,Nothing} = nothing,
+    gain_a::Real = 1.0,
+) = stitch_along(A, B, dim, seam_ratio, gain_a)
 
 function _cat_and_sort(
     A::AbstractDimArray,
     B::AbstractDimArray,
     dim::Union{Dimension,Symbol},
-    enhance_a,
+    gain_a,
 )
     along_dim = dims(A, dim)
     along_dim_idx = dimnum(A, dim)
@@ -80,7 +80,7 @@ function _cat_and_sort(
     )
     @debug "cat_dim" cat_dim
     @debug "new_along_dim" new_along_dim
-    cat_data = cat(parent(A) .* enhance_a, parent(B), dims = along_dim_idx)
+    cat_data = cat(parent(A) .* gain_a, parent(B), dims = along_dim_idx)
     @debug "size_of cat_data" size(cat_data)
     stitch_dimArray = rebuild(
         A;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ include("./fixture.jl")
         include("transform.jl")
         include("filter.jl")
         include("derivative.jl")
+        include("stitch.jl")
     end
     @testset "k_conv" begin
         include("k_conv/preprocess.jl")

--- a/test/stitch.jl
+++ b/test/stitch.jl
@@ -1,0 +1,40 @@
+using Test
+using DimensionalData
+using ARPES
+
+
+function build_arrays()
+    x = range(1.0, stop = 8.0, length = 20)
+    y = collect(range(5, stop = 9, length = 10))
+    data = collect(1.0:200) |> d->reshape(d, 20, 10)
+    A = DimArray(data, (X = x, Y = y))
+
+    x = range(3.0, stop = 15.0, length = 20)
+    y = collect(range(5, stop = 9, length = 10))
+    data = collect(1.0:200) |> d->reshape(d, 10, 20)
+    B = DimArray(data', (X = x, Y = y))
+
+    x = range(13.0, stop = 15.0, length = 10)
+    y = collect(range(5, stop = 9, length = 10))
+    data = collect(1.0:100) |> d->reshape(d, 10, 10)
+    C = DimArray(data', (X = x, Y = y))
+
+    return A, B, C
+
+end
+
+function build_arrays3D()
+    x = range(1.0, stop = 8.0, length = 20)
+    y = collect(range(5, stop = 9, length = 10))
+    z = collect(range(1, stop = 5, length = 5))
+    data = collect(1.0:1000) |> d->reshape(d, 20, 10, 5)
+    A = DimArray(data, (X = x, Y = y, Z = z))
+
+    x = range(7.0, stop = 15.0, length = 20)
+    y = collect(range(5, stop = 9, length = 10))
+    z = collect(range(1, stop = 5, length = 5))
+    data = collect(1.0:1000) * 2.1 |> d->reshape(d, 20, 10, 5)
+    B = DimArray(data, (X = x, Y = y, Z = z))
+    return A, B
+end
+

--- a/test/stitch.jl
+++ b/test/stitch.jl
@@ -1,6 +1,7 @@
 using Test
 using DimensionalData
 using ARPES
+using ARPES: phi, eV, delay
 
 
 function build_arrays()
@@ -27,17 +28,18 @@ end
 
 
 function build_arrays3D()
-    x = range(1.0, stop = 8.0, length = 20)
-    y = collect(range(5, stop = 9, length = 10))
-    z = collect(range(1, stop = 5, length = 5))
-    data = collect(1.0:1000) |> d->reshape(d, 20, 10, 5)
-    A = DimArray(data, (X = x, Y = y, Z = z))
-
     x = range(7.0, stop = 15.0, length = 20)
     y = collect(range(5, stop = 9, length = 10))
     z = collect(range(1, stop = 5, length = 5))
     data = collect(1.0:1000) * 2.1 |> d->reshape(d, 20, 10, 5)
-    B = DimArray(data, (X = x, Y = y, Z = z))
+    A = ARPESData(data, (phi = x, eV = y, delay = z))
+
+    x = range(1.0, stop = 8.0, length = 20)
+    y = collect(range(5, stop = 9, length = 10))
+    z = collect(range(1, stop = 5, length = 5))
+    data = collect(1.0:1000) |> d->reshape(d, 20, 10, 5)
+    B = ARPESData(data, (phi = x, eV = y, delay = z))
+
     return A, B
 end
 
@@ -73,5 +75,18 @@ end
         @test_throws AssertionError stitch_along(A, B_wrong, :X, 0.5, 1.0)
 
         @test_throws ErrorException stitch_along(A, A, :X, 0.5, 1.0)
+    end
+end
+
+@testset "ARPES Stitching Tests - 3D" begin
+    A, B = build_arrays3D()
+
+    @testset "Case: Overlapping Stitched (A & B)" begin
+        res = stitch_along(A, B, :phi; seam_ratio = 0.5, gain_a = 1.0)
+        @test res isa ARPESData
+        @test size(res, :phi) < (size(A, :phi) + size(B, :phi))
+        @test minimum(lookup(res, :phi)) == 1.0
+        @test maximum(lookup(res, :phi)) == 15.0
+        @test issorted(lookup(res, :phi))
     end
 end

--- a/test/stitch.jl
+++ b/test/stitch.jl
@@ -4,24 +4,27 @@ using ARPES
 
 
 function build_arrays()
-    x = range(1.0, stop = 8.0, length = 20)
-    y = collect(range(5, stop = 9, length = 10))
-    data = collect(1.0:200) |> d->reshape(d, 20, 10)
-    A = DimArray(data, (X = x, Y = y))
+    # Array A: X from 1 to 8
+    x1 = range(1.0, stop = 8.0, length = 20)
+    y1 = collect(range(5, stop = 9, length = 10))
+    data1 = collect(1.0:200) |> d -> reshape(d, 20, 10)
+    A = DimArray(data1, (X = x1, Y = y1))
 
-    x = range(3.0, stop = 15.0, length = 20)
-    y = collect(range(5, stop = 9, length = 10))
-    data = collect(1.0:200) |> d->reshape(d, 10, 20)
-    B = DimArray(data', (X = x, Y = y))
+    # Array B: X from 3 to 15 (Overlaps A)
+    x2 = range(3.0, stop = 15.0, length = 20)
+    y2 = collect(range(5, stop = 9, length = 10))
+    data2 = collect(1.0:200) |> d -> reshape(d, 10, 20)
+    B = DimArray(data2', (X = x2, Y = y2))
 
-    x = range(13.0, stop = 15.0, length = 10)
-    y = collect(range(5, stop = 9, length = 10))
-    data = collect(1.0:100) |> d->reshape(d, 10, 10)
-    C = DimArray(data', (X = x, Y = y))
+    # Array C: X from 13 to 15 (No overlap with A)
+    x3 = range(13.0, stop = 15.0, length = 10)
+    y3 = collect(range(5, stop = 9, length = 10))
+    data3 = collect(1.0:100) |> d -> reshape(d, 10, 10)
+    C = DimArray(data3', (X = x3, Y = y3))
 
     return A, B, C
-
 end
+
 
 function build_arrays3D()
     x = range(1.0, stop = 8.0, length = 20)
@@ -38,3 +41,37 @@ function build_arrays3D()
     return A, B
 end
 
+@testset "ARPES Stitching Tests" begin
+    A, B, C = build_arrays()
+
+    @testset "Case: Overlapping Stitched (A & B)" begin
+        res = stitch_along(A, B, :X, 0.5, 1.0)
+        @test res isa DimArray
+        @test size(res, :X) < (size(A, :X) + size(B, :X))
+        @test minimum(lookup(res, :X)) == 1.0
+        @test maximum(lookup(res, :X)) == 15.0
+        @test issorted(lookup(res, :X))
+    end
+
+    @testset "Case: Disjoint Stitched (A & C)" begin
+        res = stitch_along(A, C, :X, 0.5, 1.0)
+        @test size(res, :X) == size(A, :X) + size(C, :X)
+        @test issorted(lookup(res, :X))
+    end
+
+    @testset "Case: Intensity Enhancement" begin
+        gain = 2.5
+        res = stitch_along(A, C, :X, nothing, gain)
+        @test res[X(At(1.0)), Y(At(5.0))] == A[X(At(1.0)), Y(At(5.0))] * gain
+        @test res[X(At(15.0)), Y(At(5.0))] == C[X(At(15.0)), Y(At(5.0))]
+    end
+
+    @testset "Case: Error Handling" begin
+        @test_throws AssertionError stitch_along(A, B, :X, 1.2, 1.0)
+
+        B_wrong = B[Y(1:5)]
+        @test_throws AssertionError stitch_along(A, B_wrong, :X, 0.5, 1.0)
+
+        @test_throws ErrorException stitch_along(A, A, :X, 0.5, 1.0)
+    end
+end


### PR DESCRIPTION
This pull request introduces a new stitching utility for combining dimensional arrays in the ARPES package. The main addition is the `stitch_along` function, which allows two `AbstractDimArray`s to be merged along a specified dimension, with options for handling overlap and scaling. Comprehensive tests are also added to ensure correct functionality and error handling.

New stitching functionality:

* Added `src/stitch.jl` with the `stitch_along` function, enabling the merging of two `AbstractDimArray`s along a chosen dimension, supporting overlap handling via `seam_ratio` and intensity scaling via `gain_a`. Includes internal logic for overlap resolution and data sorting.
* Integrated the new stitching functionality into the main ARPES module by including `stitch.jl` in `src/ARPES.jl`.

Testing and validation:

* Added a comprehensive test suite in `test/stitch.jl` to cover overlapping, disjoint, and scaled stitching cases, as well as error scenarios (e.g., invalid overlap ratio, mismatched dimensions, identical arrays).
* Included the new stitch tests in the main test runner by updating `test/runtests.jl`.