### PR TITLE
:recycle: Rename local functions starting with _

### DIFF
--- a/src/io/formats/itx.jl
+++ b/src/io/formats/itx.jl
@@ -39,7 +39,7 @@ function read_itx(fpath::String)::DimArray
             comment = strip(comment)
 
             push!(waves_info[:raw_comments], comment)
-            parsed = _parse_comment_line(comment)
+            parsed = _parse_itx_comment_line(comment)
             if parsed !== nothing
                 merge!(waves_info, parsed)
             end
@@ -48,7 +48,7 @@ function read_itx(fpath::String)::DimArray
             continue
 
         elseif startswith(line, "WAVES")
-            parsed = _parse_waves_declaration(line)
+            parsed = _parse_itx_waves_declaration(line)
             if parsed !== nothing
                 waves_info = merge(waves_info, parsed)
             end
@@ -58,21 +58,21 @@ function read_itx(fpath::String)::DimArray
 
         elseif startswith(line, "END")
             in_data_section = false
-            wave_data = _parse_wave_data(data_lines)
+            wave_data = _parse_itx_wave_data(data_lines)
 
         elseif startswith(line, "X SetScale")
-            scale_info = _parse_setscale(line)
+            scale_info = _parse_itx_setscale(line)
             merge!(waves_info, scale_info)
 
         elseif in_data_section
             push!(data_lines, line)
         end
     end
-    return _to_dimarray(wave_data, waves_info)
+    return _itx_to_dimarray(wave_data, waves_info)
 end
 
 """
-    _parse_comment_line(comment::AbstractString)
+    _parse_itx_comment_line(comment::AbstractString)
 
 Parses a comment line from the ITX file and extracts key-value pairs or metadata.
 
@@ -85,7 +85,7 @@ Parses a comment line from the ITX file and extracts key-value pairs or metadata
 # Returns
 - `Dict{Symbol, Any}`: Dictionary of parsed metadata, or `nothing` if not applicable.
 """
-function _parse_comment_line(comment::AbstractString)
+function _parse_itx_comment_line(comment::AbstractString)
     if startswith(comment, "User Comment")
         parts = split(comment, "=", limit = 2)
         additional_waves_info = Dict{Symbol,Any}()
@@ -93,7 +93,7 @@ function _parse_comment_line(comment::AbstractString)
             key_raw = strip(parts[1])
             val_raw = strip(parts[2])
             additional_waves_info[:user_comment] = val_raw
-            info_from_comments = _parse_comment_line_comment(String(val_raw))
+            info_from_comments = _parse_itx_comment_line_comment(String(val_raw))
             return merge(additional_waves_info, info_from_comments)
         end
     end
@@ -104,7 +104,7 @@ function _parse_comment_line(comment::AbstractString)
             key_raw = strip(parts[1])
             val_raw = strip(parts[2])
             key = Symbol(lowercase(replace(key_raw, " " => "_")))
-            val = _parse_value(String(val_raw))
+            val = _parse_itx_value(String(val_raw))
             return Dict(key => val)
         end
     end
@@ -125,7 +125,8 @@ function _parse_comment_line(comment::AbstractString)
 end
 
 """
-    _build_scale(scale_info::Dict, length::Int)
+
+_build_itx_scale(scale_info::Dict, length::Int)
 
 Builds a numerical range for a dimension based on scale information.
 
@@ -136,18 +137,24 @@ Builds a numerical range for a dimension based on scale information.
 # Returns
 - `AbstractRange`: The constructed range for the dimension.
 """
-function _build_scale(scale_info::Dict, length::Int)
-    if haskey(scale_info, :min)
+function _build_itx_scale(scale_info::Dict, length::Int)
+    if haskey(scale_info, :min) && haskey(scale_info, :max)
         return range(scale_info[:min], scale_info[:max], length = length)
-    elseif haskey(scale_info, :start)
+    elseif haskey(scale_info, :start) && haskey(scale_info, :step)
         return range(scale_info[:start], step = scale_info[:step], length = length)
+    elseif haskey(scale_info, :start) && haskey(scale_info, :right)
+        return range(
+            scale_info[:start],
+            step = (scale_info[:right] - scale_info[:start])/length,
+            length = length,
+        )
     else
         error("Invalid scale information")
     end
 end
 
 """
-    _parse_comment_line_comment(comment::String)
+    _parse_itx_comment_line_comment(comment::String)
 
 Parses a semicolon-separated comment string into key-value pairs.
 
@@ -161,14 +168,14 @@ Example:
 - `Dict{Symbol, Any}`: Dictionary of parsed key-value pairs.
 
 """
-function _parse_comment_line_comment(comment::String)
+function _parse_itx_comment_line_comment(comment::String)
     additional_waves_info = Dict{Symbol,Any}()
     comments = split(comment, ";")
     for info in comments
         info_item = split(info, ":")
         if length(info_item) >= 2
             key = Symbol(lowercase(replace(info_item[1], " " => "_")))
-            additional_waves_info[key] = _parse_value(String(info_item[2]))
+            additional_waves_info[key] = _parse_itx_value(String(info_item[2]))
         end
     end
     return additional_waves_info
@@ -176,7 +183,7 @@ end
 
 
 """
-    _parse_value(val_str::String)
+    _parse_itx_value(val_str::String)
 
 Converts a string value to an appropriate type (Int, Float64, or String).
 
@@ -186,7 +193,7 @@ Converts a string value to an appropriate type (Int, Float64, or String).
 # Returns
 - `Int`, `Float64`, or `String`: The parsed value.
 """
-function _parse_value(val_str::String)
+function _parse_itx_value(val_str::String)
     val_str = strip(val_str)
 
     # Try to interpret as number
@@ -205,7 +212,7 @@ function _parse_value(val_str::String)
 end
 
 """
-    _parse_wave_data(data_lines::Vector{String})
+    _parse_itx_wave_data(data_lines::Vector{String})
 
 Parses lines of wave data into a 1D array of Float64 values.
 
@@ -215,7 +222,7 @@ Parses lines of wave data into a 1D array of Float64 values.
 # Returns
 - `Vector{Float64}`: Parsed numeric data.
 """
-function _parse_wave_data(data_lines::Vector{String})
+function _parse_itx_wave_data(data_lines::Vector{String})
     all_values = Float64[]
     for line in data_lines
         if isempty(strip(line))
@@ -237,7 +244,7 @@ end
 
 
 """
-    _to_dimarray(data::Array, waves_info::Dict)
+    _itx_to_dimarray(data::Array, waves_info::Dict)
 
 Converts parsed data and metadata into a `DimArray` with appropriate dimensions and metadata.
 
@@ -248,13 +255,18 @@ Converts parsed data and metadata into a `DimArray` with appropriate dimensions 
 # Returns
 - `DimArray`: The constructed dimensional array.
 """
-function _to_dimarray(data::Array, waves_info::Dict)::DimArray
+function _itx_to_dimarray(data::Array, waves_info::Dict)::DimArray
     # Construct dimension
     dims_list = []
     @debug "waves_info" waves_info[:shape]
     @debug "data length" length(data)
     if haskey(waves_info, :shape)
         shape = waves_info[:shape]
+
+        @debug "length(data)" length(data)
+        @debug "shape" shape
+        @debug "prod(shape)" prod(shape)
+
         shape_itx = (shape[2], shape[1], shape[3:end]...)
         nd = length(shape)
         @debug "nd, shape" nd shape
@@ -268,7 +280,7 @@ function _to_dimarray(data::Array, waves_info::Dict)::DimArray
         if ndims(data) >= i && haskey(waves_info, key)
             info = waves_info[key]
             n = size(data, i)
-            vals = _build_scale(info, n)
+            vals = _build_itx_scale(info, n)
             default_name = Symbol(string(key)[1])
             label = get(info, :label, nothing)
             dim_name = (label === nothing || isempty(label)) ? default_name : Symbol(label)
@@ -299,7 +311,7 @@ function _to_dimarray(data::Array, waves_info::Dict)::DimArray
 end
 
 """
-    _parse_waves_declaration(line::AbstractString)
+    _parse_itx_waves_declaration(line::AbstractString)
 
 Parses a WAVES declaration line from the ITX file and extracts wave metadata.
 
@@ -313,7 +325,7 @@ Example:
 # Returns
 - `Dict{Symbol, Any}`: Dictionary of parsed wave metadata.
 """
-function _parse_waves_declaration(line::AbstractString)
+function _parse_itx_waves_declaration(line::AbstractString)
     info = Dict{Symbol,Any}()
 
     # Extract flag part (/S, /N=...)
@@ -361,7 +373,7 @@ function _parse_waves_declaration(line::AbstractString)
 end
 
 """
-    _parse_setscale(line::AbstractString)
+    _parse_itx_setscale(line::AbstractString)
 
 Parses a SetScale line from the ITX file and extracts axis scaling information.
 
@@ -378,7 +390,7 @@ Examples:
 # Returns
 - `Dict{Symbol, Any}`: Dictionary containing axis scale information.
 """
-function _parse_setscale(line::AbstractString)
+function _parse_itx_setscale(line::AbstractString)
     # SetScale/I x, min, max, "unit (label)", 'wave'
     # SetScale/P x, start, step, "unit", "label"
     parts = split(line, ",")
@@ -436,6 +448,17 @@ function _parse_setscale(line::AbstractString)
                 axis_key => Dict(
                     :start => start_val,
                     :step => step_val,
+                    :unit => unit,
+                    :label => label,
+                ),
+            )
+        elseif mode==:default
+            start_val = parse(Float64, strip(parts[2]))
+            right_val = parse(Float64, strip(parts[3]))
+            return Dict(
+                axis_key => Dict(
+                    :start => start_val,
+                    :right => right_val,
                     :unit => unit,
                     :label => label,
                 ),

--- a/test/io/formats/itx.jl
+++ b/test/io/formats/itx.jl
@@ -2,26 +2,26 @@ using Test
 using ARPES
 using DimensionalData
 
-@testset "_parse_waves_declaration basic test" begin
+@testset "_parse_itx_waves_declaration basic test" begin
     decl = "WAVES/D/N=5 testwave"
-    result = ARPES.IO.Format._parse_waves_declaration(decl)
+    result = ARPES.IO.Format._parse_itx_waves_declaration(decl)
     @test result[:name] == "testwave"
     @test result[:n] == 5
     @test result[:type] == :double_precision
 end
 
-@testset "_parse_waves_declaration single precision, quoted name, shape" begin
+@testset "_parse_itx_waves_declaration single precision, quoted name, shape" begin
     decl = "WAVES/S/N=(200,2401) 'GrIr111_1'"
-    result = ARPES.IO.Format._parse_waves_declaration(decl)
+    result = ARPES.IO.Format._parse_itx_waves_declaration(decl)
     @test result[:name] == "GrIr111_1"
     @test result[:n] == 200
     @test result[:type] == :single_precision
     @test result[:shape] == (200, 2401)
 end
 
-@testset "_parse_waves_declaration default type, unquoted name" begin
+@testset "_parse_itx_waves_declaration default type, unquoted name" begin
     decl = "WAVES/N=10 mywave"
-    result = ARPES.IO.Format._parse_waves_declaration(decl)
+    result = ARPES.IO.Format._parse_itx_waves_declaration(decl)
     @test result[:name] == "mywave"
     @test result[:n] == 10
     @test result[:type] == :double_precision
@@ -29,9 +29,9 @@ end
 
 
 #setscale line format:
-@testset "_parse_setscale! basic test" begin
+@testset "_parse_itx_setscale! basic test" begin
     line = "X SetScale/I x, -11.44, 12.44, \"deg (theta_y)\", 'GrIr111_1'"
-    waves_info = ARPES.IO.Format._parse_setscale(line)
+    waves_info = ARPES.IO.Format._parse_itx_setscale(line)
     @test haskey(waves_info, :x_scale)
     xscale = waves_info[:x_scale]
     @test xscale[:min] ≈ -11.44
@@ -40,9 +40,9 @@ end
     @test xscale[:label] == "theta_y"
 end
 
-@testset "_parse_setscale! no label" begin
+@testset "_parse_itx_setscale! no label" begin
     line = "X SetScale/I y, 0, 100, \"eV\", 'wave1'"
-    waves_info = ARPES.IO.Format._parse_setscale(line)
+    waves_info = ARPES.IO.Format._parse_itx_setscale(line)
     @test haskey(waves_info, :y_scale)
     yscale = waves_info[:y_scale]
     @test yscale[:min] == 0
@@ -51,9 +51,9 @@ end
     @test isnothing(yscale[:label])
 end
 
-@testset "_parse_setscale! " begin
+@testset "_parse_itx_setscale! " begin
     line = "X SetScale/I x, -10.6875, 10.6875, \"deg (Non-Energy Channel)\", 'Region1_1'"
-    waves_info = ARPES.IO.Format._parse_setscale(line)
+    waves_info = ARPES.IO.Format._parse_itx_setscale(line)
     @test haskey(waves_info, :x_scale)
     xscale = waves_info[:x_scale]
     @test xscale[:min] ≈ -10.6875
@@ -62,9 +62,9 @@ end
     @test xscale[:label] == "non_energy_channel"
 end
 
-@testset "_parse_setscale! basic test perpoints" begin
+@testset "_parse_itx_setscale! basic test perpoints" begin
     line = "X SetScale/P y, 5.2, 0.002, \"eV\", 'GrIr111_1'"
-    waves_info = ARPES.IO.Format._parse_setscale(line)
+    waves_info = ARPES.IO.Format._parse_itx_setscale(line)
     @test haskey(waves_info, :y_scale)
     yscale = waves_info[:y_scale]
     @test yscale[:start] ≈ 5.2
@@ -73,46 +73,62 @@ end
     @test isnothing(yscale[:label])
 end
 
+@testset "_parse_itx_setscale! default (but rare used) mode " begin
+    line = "X SetScale x, 0,10, \"\", test1D"
+    waves_info = ARPES.IO.Format._parse_itx_setscale(line)
+    @test haskey(waves_info, :x_scale)
+    xscale = waves_info[:x_scale]
+    @test xscale[:start] == 0
+    @test xscale[:right] == 10
+    @test xscale[:unit] == ""
+    @test isnothing(xscale[:label])
+
+    built_scale = ARPES.IO.Format._build_itx_scale(xscale, 10)
+    @test built_scale[1] == 0
+    @test built_scale[10] == 9
+end
+
+
 # comment line:
-@testset"_parse_comment_line created_date" begin
+@testset"_parse_itx_comment_line created_date" begin
     line = "Created Date (UTC): 2025-Dec-25 10:04:00.189347"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:created_date] == "2025-Dec-25 10:04:00.189347"
 end
 
-@testset"_parse_comment_line created_by" begin
+@testset"_parse_itx_comment_line created_by" begin
     line = "Created by: SpecsLab Prodigy, Version 4.123.1-r123826 "
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:created_by] == "SpecsLab Prodigy, Version 4.123.1-r123826"
 end
 
-@testset"_parse_comment_line scan_mode" begin
+@testset"_parse_itx_comment_line scan_mode" begin
     line = "Scan Mode         = Fixed Analyzer Transmission"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:scan_mode] == "Fixed Analyzer Transmission"
 end
 
-@testset"_parse_comment_line number_of_scan" begin
+@testset"_parse_itx_comment_line number_of_scan" begin
     line = "Number of Scans   = 16"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:number_of_scans] == 16
 end
 
-@testset"_parse_comment_line photon energy" begin
+@testset"_parse_itx_comment_line photon energy" begin
     line = "Excitation Energy = 4.708"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:excitation_energy] ≈ 4.708
 end
 
-@testset"_parse_comment_line not include" begin
+@testset"_parse_itx_comment_line not include" begin
     line = "Acquisition Parameters:"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test isnothing(result)
 end
 
-@testset"_parse_comment_line comment" begin
+@testset"_parse_itx_comment_line comment" begin
     line = "User Comment      = beta:0;Temperature:RT;X:13.5;Y:21.55;Z:+00346000;theta:-00270000;position:187.4655;UV(P);IR(P);+w;P:113mW;+3w;P:6mW;"
-    result = ARPES.IO.Format._parse_comment_line(line)
+    result = ARPES.IO.Format._parse_itx_comment_line(line)
     @test result[:user_comment] ==
           "beta:0;Temperature:RT;X:13.5;Y:21.55;Z:+00346000;theta:-00270000;position:187.4655;UV(P);IR(P);+w;P:113mW;+3w;P:6mW;"
     @test result[:beta] == 0
@@ -122,9 +138,9 @@ end
     @test result[:position] ≈ 187.4655
 end
 
-@testset"_parse_comment_line_comment" begin
+@testset"_parse_itx_comment_line_comment" begin
     line = "beta:0;Temperature:RT;X:13.5;Y:21.55;Z:+00346000;theta:-00270000;position:187.4655;UV(P);IR(P);+w;P:113mW;+3w;P:6mW;"
-    result = ARPES.IO.Format._parse_comment_line_comment(line)
+    result = ARPES.IO.Format._parse_itx_comment_line_comment(line)
     @test result[:beta] == 0
     @test result[:temperature] == "RT"
     @test result[:x] ≈ 13.5
@@ -132,7 +148,7 @@ end
     @test result[:position] ≈ 187.4655
 end
 
-@testset"_parse_wave_data" begin
+@testset"_parse_itx_wave_data" begin
     line1 = "67.8969 67.8969 71.7938 75.7938 77.8969 83.6906 84 85.8969 86 86 87.8969"
     line2 = ""
     line3 = "54.8032 54.8032 57.6065 60 60 63.213 69.6065 71.1968"
@@ -140,7 +156,7 @@ end
     push!(data_lines, line1)
     push!(data_lines, line2)
     push!(data_lines, line3)
-    result = ARPES.IO.Format._parse_wave_data(data_lines)
+    result = ARPES.IO.Format._parse_itx_wave_data(data_lines)
     @test result[1] ≈ 67.8969
     @test length(result) == 19
     @test result[19] ≈ 71.1968


### PR DESCRIPTION
   ## Summary

   - Rename ITX parser internal helper functions to ITX-specific names
   - Update direct unit tests to follow the renamed internal APIs
   - Add tests for `_parse_itx_setscale` default mode and `_build_itx_scale`

   ## Details

   The internal helper names in `src/io/formats/itx.jl` were a bit too generic for module-scoped functions.
   This change makes them explicitly ITX-specific, which reduces the chance of future naming conflicts and makes test targets easier
  to understand.

   Examples:
   - `_parse_setscale` -> `_parse_itx_setscale`
   - `_build_scale` -> `_build_itx_scale`
   - `_parse_waves_declaration` -> `_parse_itx_waves_declaration`
   - `_parse_comment_line` -> `_parse_itx_comment_line`

   The corresponding tests were updated as well, and coverage was extended for scale parsing/building behavior.

   ## Motivation

   In Julia, `_`-prefixed functions are still module-level names, so generic internal names can still become ambiguous as the format
  layer grows.
   Using ITX-specific names keeps the implementation clearer without introducing extra module boundaries.
