### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.1] — 2026-XX-XX
+## [0.2.1] — 2026-04-13
 
 ### Added
 
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Handles overlapping regions: `seam_ratio` controls the split point within the overlap (0–1; `nothing` concatenates directly without splitting).
   - `gain_a` applies a multiplicative scale to the first array before concatenating.
   - Result is always sorted along the stitched dimension.
+
+### Fixed
+
+- Fixed insufficient parse option in SetScale in `load_itx` ([#63]).
 
 ## [0.2.0] — 2026-04-08
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ARPES"
 uuid = "3764e38b-e87f-453d-b456-dc646f8e1bb8"
-version = "0.2.1dev"
+version = "0.2.1"
 authors = ["Ryuichi Arafune"]
 
 [deps]


### PR DESCRIPTION
This pull request updates the changelog to reflect the latest release date and documents a recent bug fix. The most important changes are:

Changelog updates:

* Updated the release date for version 0.2.1 in `CHANGELOG.md` to 2026-04-13.

Bug fixes:

* Added a "Fixed" section in `CHANGELOG.md` noting the resolution of an insufficient parse option in SetScale within `load_itx`.