### PR TITLE
Dim extend shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] — 2026-04-14
+## [0.2.2] — 2026-XX-XX
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] — 2026-04-14
+
+### Added
+
+- `dim_extend` keyword argument for `shift`
+  - Supports scalar, vector, and one-dimensional `AbstractDimArray` shift inputs.
+  - Extends equally spaced shift dimensions so shifted data is preserved on a larger output axis.
+
+### Changed
+
+- Consolidated and expanded the `shift` docstrings to document scalar shifts, per-dimension shifts, irregular-grid behavior, and `dim_extend`.
+
 ## [0.2.1] — 2026-04-13
 
 ### Added

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -50,30 +50,38 @@ function rebin(data::AbstractDimArray, dim::Union{Symbol,Dimension}, bins::Bins)
 end
 
 """
-    shift(
-        data::AbstractDimArray,
-        shift_dim::Union{Symbol, Dimension},
-        other_dim::Union{Symbol, Dimension},
-        values::AbstractVector{<:Real},
-    )
+    shift(data::AbstractDimArray, shift_dim::Union{Symbol, Dimension}, other_dim::Union{Symbol, Dimension}, values::AbstractVector{<:Real})
+    shift(data::AbstractDimArray, shift_dim::Union{Symbol, Dimension}, values::AbstractDimArray)
+    shift(data::AbstractDimArray, shift_dim::Union{Symbol, Dimension}, value::Real)
 
-Shift the `data` array along `shift_dim` by an amount specified in `values`,
-for each position along `other_dim`.
+Shift `data` along `shift_dim` using linear interpolation.
 
-- `data`: An `AbstractDimArray` to be shifted.
-- `shift_dim`: The dimension along which to shift (as a `Symbol` or `Dimension`).
-- `other_dim`: The dimension whose index determines which value from `values` to use.
-- `values`: A vector of shift values, one for each index along `other_dim`.
+# Arguments
+- `data`: The input `AbstractDimArray` to be shifted.
+- `shift_dim`: The dimension (as a `Symbol` or `Dimension`) along which to shift.
 
-Returns a new `DimArray` with the same shape and metadata as `data`, shifted accordingly.
+- `value`: Apply a uniform scalar shift along `shift_dim`.
+- `other_dim`, `values`: Apply shifts that vary along `other_dim`, using one value for each index along that dimension.
+- `values::AbstractDimArray`: A one-dimensional shorthand where the dimension of `values` determines `other_dim`.
+- `dim_extend=false`: When `true`, rebuild `shift_dim` on an extended axis with the same step size.
 
-Throws `ArgumentError` if the dimensions or value lengths do not match requirements.
+For equally spaced coordinates, shifting is performed directly in index space.
+For monotonic irregular coordinates, the implementation falls back to irregular-grid handling.
+Dimension extension is supported only for equally spaced coordinates.
+
+# Returns
+A new `DimArray` with the shifted data. When `dim_extend=true`, the returned array is larger along `shift_dim`.
+
+# Throws
+- `ArgumentError`: If `values` is not one-dimensional, if a requested dimension is missing, if the length of `values` does not match the size of `other_dim`, or if `dim_extend=true` is used with a non-equally-spaced `shift_dim`.
 """
 function shift(
     data::AbstractDimArray,
     shift_dim::Union{Symbol,Dimension},
     other_dim::Union{Symbol,Dimension},
     values::AbstractVector{<:Real},
+    ;
+    dim_extend::Bool = false,
 )
 
     if ndims(data) < 2
@@ -97,6 +105,11 @@ function shift(
     odim = dimnum(data, other_dim)
 
     coords_vec = collect(dims(data, shift_dim))
+    if dim_extend
+        _is_equal_spacing(coords_vec) ||
+            throw(ArgumentError("dim_extend=true requires shift_dim to be equally spaced."))
+        return _shift_with_dim_extend(data, shift_dim, other_dim, values)
+    end
     if !_is_equal_spacing(coords_vec)
         return _shift_irregular(data, shift_dim, other_dim, values)
     end
@@ -120,31 +133,21 @@ function shift(
     return DimArray(result; dims = dims(data))
 end
 
-"""
-    shift_optimized(data::AbstractDimArray,
-                    shift_dim::Union{Symbol, Dimension},
-                    value::Real)
-
-Shift `data` along `shift_dim` by a scalar `value`.
-
-- `shift_dim` must be equally spaced.
-- A single shift value is applied uniformly along `shift_dim`.
-- Subpixel shift is performed via linear interpolation.
-- Returns an array with the same shape and metadata.
-
-# Arguments
-- `data` : AbstractDimArray
-- `shift_dim` : Dimension to shift along
-- `value` : scalar shift amount
-
-# Returns
-- AbstractDimArray with the same size and metadata
-"""
-function shift(data::AbstractDimArray, shift_dim::Union{Symbol,Dimension}, value::Real)
+function shift(
+    data::AbstractDimArray,
+    shift_dim::Union{Symbol,Dimension},
+    value::Real;
+    dim_extend::Bool = false,
+)
 
     sdim = dimnum(data, shift_dim)
 
     coords_vec = collect(dims(data, shift_dim))
+    if dim_extend
+        _is_equal_spacing(coords_vec) ||
+            throw(ArgumentError("dim_extend=true requires shift_dim to be equally spaced."))
+        return _shift_with_dim_extend(data, shift_dim, value)
+    end
     if !_is_equal_spacing(coords_vec)
         return _shift_irregular(data, shift_dim, value)
     end
@@ -166,36 +169,90 @@ function shift(data::AbstractDimArray, shift_dim::Union{Symbol,Dimension}, value
     return DimArray(result; dims = dims(data))
 end
 
-"""
-    shift(
-        data::AbstractDimArray,
-        shift_dim::Union{Symbol, Dimension},
-        values::AbstractDimArray,
-    )
-
-Shift an `AbstractDimArray` object along `shift_dim` by values provided in a one-dimensional `AbstractDimArray`.
-
-- `data`: An `AbstractDimArray` object to be shifted.
-- `shift_dim`: The dimension along which to shift (as a `Symbol` or `Dimension`).
-- `values`: A one-dimensional `AbstractDimArray` of shift values.
-
-Returns a new `DimArray` with the same shape and metadata as `data`, shifted accordingly.
-
-Throws `ArgumentError` if `values` is not one-dimensional.
-"""
 function shift(
     data::AbstractDimArray,
     shift_dim::Union{Symbol,Dimension},
     values::AbstractDimArray,
+    ;
+    dim_extend::Bool = false,
 )
     @debug "values are AbstractDimArray"
-    if ndims(values) != 1
-        error_msg = "Values must be a one-dimensional array."
-        throw(ArgumentError(error_msg))
-    end
-    other_dim = name(dims(values))[1]
+    other_dim = only(name(dims(values)))
     values = parent(values)
-    shift(data, shift_dim, other_dim, values)
+    shift(data, shift_dim, other_dim, values; dim_extend)
+end
+
+function _build_extended_shift_dim(dim::Dimension, shift_range::Tuple{<:Real,<:Real})
+    coords = collect(parent(lookup(dim)))
+    _is_equal_spacing(coords) ||
+        throw(ArgumentError("dim_extend=true requires shift_dim to be equally spaced."))
+
+    Δ = coords[2] - coords[1]
+    min_shift, max_shift = shift_range
+    extension_steps = ceil(Int, (max_shift - min_shift) / abs(Δ))
+    start = coords[1] + (Δ > 0 ? min_shift : max_shift)
+    extended_lookup = range(start, step = Δ, length = length(coords) + extension_steps)
+    return rebuild(dim; val = extended_lookup)
+end
+
+function _shift_with_dim_extend(
+    data::AbstractDimArray,
+    shift_dim::Union{Symbol,Dimension},
+    other_dim::Union{Symbol,Dimension},
+    values::AbstractVector{<:Real},
+)
+    sdim = dimnum(data, shift_dim)
+    odim = dimnum(data, other_dim)
+    shift_axis = dims(data, shift_dim)
+    coords_vec = collect(parent(lookup(shift_axis)))
+    c1 = coords_vec[1]
+    Δ = coords_vec[2] - c1
+
+    extended_dim = _build_extended_shift_dim(shift_axis, (minimum(values), maximum(values)))
+    extended_coords = collect(parent(lookup(extended_dim)))
+    out_size = ntuple(d -> d == sdim ? length(extended_coords) : size(data, d), ndims(data))
+    result = similar(parent(data), out_size)
+    itp = extrapolate(interpolate(data, BSpline(Linear())), NaN)
+
+    result .= (i -> begin
+        target_idx = (extended_coords[i[sdim]] - values[i[odim]] - c1) / Δ + 1
+        idx_tuple = Tuple(i)
+        return itp(Base.setindex(idx_tuple, target_idx, sdim)...)
+    end).(
+        CartesianIndices(result),
+    )
+
+    new_dims = Base.setindex(dims(data), extended_dim, sdim)
+    return rebuild(data; data = result, dims = new_dims)
+end
+
+function _shift_with_dim_extend(
+    data::AbstractDimArray,
+    shift_dim::Union{Symbol,Dimension},
+    value::Real,
+)
+    sdim = dimnum(data, shift_dim)
+    shift_axis = dims(data, shift_dim)
+    coords_vec = collect(parent(lookup(shift_axis)))
+    c1 = coords_vec[1]
+    Δ = coords_vec[2] - c1
+
+    extended_dim = _build_extended_shift_dim(shift_axis, (value, value))
+    extended_coords = collect(parent(lookup(extended_dim)))
+    out_size = ntuple(d -> d == sdim ? length(extended_coords) : size(data, d), ndims(data))
+    result = similar(parent(data), out_size)
+    itp = extrapolate(interpolate(data, BSpline(Linear())), NaN)
+
+    result .= (i -> begin
+        target_idx = (extended_coords[i[sdim]] - value - c1) / Δ + 1
+        idx_tuple = Tuple(i)
+        return itp(Base.setindex(idx_tuple, target_idx, sdim)...)
+    end).(
+        CartesianIndices(result),
+    )
+
+    new_dims = Base.setindex(dims(data), extended_dim, sdim)
+    return rebuild(data; data = result, dims = new_dims)
 end
 
 function _shift_irregular(
@@ -370,5 +427,3 @@ function rebuild_with_slice(A::AbstractDimArray, dimsel, X::AbstractDimArray)
     B[dimsel] = parent(X)
     return B
 end
-
-

--- a/test/transform.jl
+++ b/test/transform.jl
@@ -104,6 +104,10 @@ end
     shift_2d_1 = shift(test_dim2D_1, :Y, -0.5)
     @test isequal(parent(shift_2d_1), [2.5 5.5 8.5 NaN; 3.5 6.5 9.5 NaN; 4.5 7.5 10.5 NaN])
 
+    shift_2d_1_extended = shift(test_dim2D_1, :Y, -0.5; dim_extend = true)
+    @test collect(lookup(dims(shift_2d_1_extended, :Y))) == [4.5, 5.5, 6.5, 7.5]
+    @test isequal(parent(shift_2d_1_extended), parent(test_dim2D_1))
+
     shift_2d_2 = _shift_irregular(test_dim2D_1, :Y, -0.5)
     @test isequal(parent(shift_2d_2), [2.5 5.5 8.5 NaN; 3.5 6.5 9.5 NaN; 4.5 7.5 10.5 NaN])
 
@@ -116,6 +120,18 @@ end
     @test all(isnan, shift_3d_2[Z=At(14)])
     shift_amount_along_y = DimArray([-0.5, -1.0, -1.5, -2.0], Y([5.0, 6.0, 7.0, 8]))
     @test isequal(parent(shift_3d_2), shift(test_dim3D_1, :Z, shift_amount_along_y))
+
+    shift_3d_2_extended = shift(test_dim3D_1, :Z, :Y, [-0.5, -1.0, -1.5, -2.0]; dim_extend = true)
+    @test collect(lookup(dims(shift_3d_2_extended, :Z))) == collect(8.0:14.0)
+    @test size(shift_3d_2_extended, :Z) == 7
+    @test isequal(
+        parent(shift_3d_2_extended[Y=At(8.0)]),
+        hcat(parent(test_dim3D_1[Y=At(8.0)]), fill(NaN, 3, 2)),
+    )
+    @test isequal(
+        parent(shift_3d_2_extended),
+        parent(shift(test_dim3D_1, :Z, shift_amount_along_y; dim_extend = true)),
+    )
 
     @test_throws ArgumentError shift(test_dim3D_1, :Z, test_dim2D_1)
     @test_throws ArgumentError shift(test_dim3D_1, :Z, :X, [-0.5, -1.0])
@@ -149,10 +165,11 @@ end
     shift_3d_2_2 = shift(test_dim3D_2, :Z, :Y, [-0.5, -1.0, -1.5, -2.0])
     @test all(isnan, shift_3d_2_2[Z=At(14)])
     shift_3d_2_3 = shift(test_dim3D_2, :Z, -0.5)
+    @test_throws ArgumentError shift(test_dim3D_2, :Z, :Y, [-0.5, -1.0, -1.5, -2.0]; dim_extend = true)
+    @test_throws ArgumentError shift(test_dim3D_2, :Z, -0.5; dim_extend = true)
 
     test_dim3D_3 = test_DimArray3D_irregular_unordered()
     @test_throws ArgumentError shift(test_dim3D_3, :Z, :Y, [-0.5, -1.0, -1.5, -2.0])
     @test_throws ArgumentError shift(test_dim3D_3, :Z, -0.5)
 end
-
 


### PR DESCRIPTION
This pull request introduces a new `dim_extend` keyword argument to the `shift` function, allowing users to extend the shifted dimension so that all shifted data is preserved on a larger output axis. The changes also consolidate and expand the documentation for `shift`, and add comprehensive tests for the new functionality. The implementation ensures that dimension extension is only available for equally spaced axes and raises informative errors otherwise.

**New features:**
* Added a `dim_extend` keyword argument to `shift`, supporting scalar, vector, and one-dimensional `AbstractDimArray` shift inputs. When enabled, the output axis is extended so no shifted data is is lost. [[1]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939L53-R84) [[2]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939R108-R112) [[3]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939L123-R150) [[4]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939L169-R255) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R19)

**Documentation improvements:**
* Consolidated and expanded the `shift` docstrings to document all input modes, irregular-grid behavior, and the new `dim_extend` option.

**Implementation details and error handling:**
* Dimension extension is only allowed for equally spaced axes; attempts to use it on irregular axes throw an `ArgumentError`. [[1]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939R108-R112) [[2]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939L123-R150) [[3]](diffhunk://#diff-1496ce88c09bd094f6a0907d8f20e7cfeeff8c8f004885f655d0ee8c456e0939L169-R255) [[4]](diffhunk://#diff-c852917f847eae69f946e91f1db1ef3aba094a0f2189c26302a70b8b8c4015b3R168-L158)
* Added internal helpers (`_build_extended_shift_dim`, `_shift_with_dim_extend`) for building extended axes and performing the shift.

**Testing:**
* Added tests for the new `dim_extend` functionality, including checks for correct output axes, data preservation, and error cases. [[1]](diffhunk://#diff-c852917f847eae69f946e91f1db1ef3aba094a0f2189c26302a70b8b8c4015b3R107-R110) [[2]](diffhunk://#diff-c852917f847eae69f946e91f1db1ef3aba094a0f2189c26302a70b8b8c4015b3R124-R135) [[3]](diffhunk://#diff-c852917f847eae69f946e91f1db1ef3aba094a0f2189c26302a70b8b8c4015b3R168-L158)

**Changelog:**
* Updated `CHANGELOG.md` with a new section for version 0.2.2, documenting the new feature and documentation changes.