### PR TITLE
Update dimensions, preprocessing, and trapezoid calculations

### DIFF
--- a/src/dims.jl
+++ b/src/dims.jl
@@ -269,8 +269,15 @@ end
 Negate the lookup values of a dimension.
 """
 function negate_dim(dim::DimensionalData.Dimension)
+    old_lookup = lookup(dim)
     new_lookup = _negate_lookup(lookup(dim))
-    return rebuild(dim; val = new_lookup)
+
+    @debug "negate_dim_check" length(parent(old_lookup)) length(new_lookup)
+
+    negated_dim = rebuild(dim; val = new_lookup)
+
+    @debug "negate_dim after rebuild" length(parent(lookup(negated_dim)))
+    return negated_dim
 end
 
 function negate_dim(data::AbstractDimArray, dim_label::Symbol)

--- a/src/k_conv/k_conversion.jl
+++ b/src/k_conv/k_conversion.jl
@@ -92,10 +92,16 @@ function k_conversion(  # kp version
     @debug "Kinetic energy ref to analyzer" ek
     # 1.2. angles  * α, β_, χ_, δ_, ξ_
     #  * apply offset & and convert degree to radian.
+    #
+    @debug "negate_alpha check" get(md, :negate_alpha, false)
     α =
         get(md, :negate_alpha, false) == true ?
         _deg2rad(parent(negate_dim(dims(data, :phi)))) :
         _deg2rad(parent(lookup(data, :phi)))
+
+    @debug "alpha check" length(α) size(parent(data)) length(parent(ek_original))
+    @debug "phi check" length(parent(lookup(data, :phi))) lookup(data, :phi)
+
     β = md[:β]
     β_ = _deg2rad(β, β0)
     ξ_ = _deg2rad(md[:ξ], ξ0)
@@ -472,7 +478,7 @@ function _deg2rad(angle_deg::AbstractRange, offset_deg::Real = 0.0)
     return range(
         (first(angle_deg) - offset_deg) * (π/180);
         step = step(angle_deg) * (π/180),
-        stop = (last(angle_deg) - offset_deg) * (π/180),
+        length = length(angle_deg),
     )
 end
 

--- a/src/k_conv/preprocess.jl
+++ b/src/k_conv/preprocess.jl
@@ -1,3 +1,4 @@
+using Statistics
 using DimensionalData: Dimension
 using ..ARPES: EnergyDefinition
 using ..ARPES: BindingEnergy, FinalStateEnergy, KineticEnergy, IntermediateEnergy
@@ -194,7 +195,7 @@ Determine the ky range for the given analyzer configuration and parameters.
 function _ky_range(
     analyzer_conf::Type{<:AbstractAnalyzerConfiguration},
     α::AbstractVector{<:Real},
-    β_::Union{AbstractVector{<:Real},Real},
+    β_::AbstractVector{<:Real},
     ek::AbstractVector{<:Real},
     χ_::Real,
     ξ_::Real,
@@ -210,6 +211,20 @@ function _ky_range(
         return min_ky
     end
     return range(start = min_ky, stop = max_ky, step = step_ky)
+end
+
+function _ky_range(
+    analyzer_conf::Type{<:AbstractAnalyzerConfiguration},
+    α::AbstractVector{<:Real},
+    β_::Real,
+    ek::AbstractVector{<:Real},
+    χ_::Real,
+    ξ_::Real,
+    δ_::Real,
+)
+    ek_min = minimum(ek)
+    ky_ = mapped_ky(analyzer_conf, prepare_for_broadcast(α, β_, ek_min)..., χ_, ξ_, δ_)
+    return mean(filter(!isnan, ky_))
 end
 
 """

--- a/src/k_conv/preprocess.jl
+++ b/src/k_conv/preprocess.jl
@@ -78,17 +78,9 @@ function _ek_range(
     hv::Real,
 )
     if energy_def == FinalStateEnergy
-        return range(
-            first(ek) - workfunction;
-            step = step(ek),
-            stop = last(ek) - workfunction,
-        )
+        return range(first(ek) - workfunction; step = step(ek), length = length(ek))
     elseif energy_def == BindingEnergy
-        return range(
-            first(ek) + hv - workfunction;
-            step = step(ek),
-            stop = last(ek) + hv - workfunction,
-        )
+        return range(first(ek) + hv - workfunction; step = step(ek), length = length(ek))
     end
 end
 
@@ -151,6 +143,7 @@ function _kx_range(
     ek_min = minimum(ek)
 
     kx_ = mapped_kx(analyzer_conf, prepare_for_broadcast(α, β_, ek_min)..., χ_, ξ_, δ_)
+
     d_kx = abs.(diff(kx_, dims = 1))
     step_kx = isempty(d_kx) ? nothing : minimum(d_kx)
     @debug "min_kx, max_kx, step_kx @ minimum ek" minimum(kx_) maximum(kx_) step_kx ek_min
@@ -161,7 +154,9 @@ function _kx_range(
     if step_kx === nothing || step_kx == 0.0
         return min_kx
     end
-    return range(start = min_kx, stop = max_kx, step = step_kx)
+    kx_range = range(start = min_kx, stop = max_kx, step = step_kx)
+    @debug "kx_range length" length(kx_range)
+    return kx_range
 end
 
 """
@@ -238,7 +233,7 @@ Check if the given `ARPESData` object contains the required dimensions and metad
 function _check_arpesdata(data::ARPESData)
     # check if the required dimensions and metadata are present
     #
-    for dim in [phi, eV]
+    for dim in [:phi, :eV]
         if !hasdim(data, dim)
             throw(ArgumentError("Missing required dimension: $(name(dim))"))
         end

--- a/src/trapezoid.jl
+++ b/src/trapezoid.jl
@@ -31,7 +31,7 @@ angles.
 # Argumetns
 
 - `A`: The input `ARPESData` to be transformed.
-- `trapezoid_corners`: The coordinate of the trapezoid corners.
+   - `trapezoid_corners`: The coordinate of the trapezoid corners (UL, UR, LL, LR).
    The tuple of four Named tuple that specifies corners of the trapezoid, the key must be both `:eV` and `:phi`.
 - `base_corners`: The tuple of two the phi values of the trensposed rectangle corners. (i.e. L_Rect and R_Rect).
    if not specified (None), use the extrema(A, :phi). Defaults to None.
@@ -53,8 +53,8 @@ function trapezoid(  # convert from trapezoid
     @assert _is_equal_spacing(lookup(A, :phi)) "A must be equally spaced along :phi dimension"
 
     UL, UR, LL, LR = trapezoid_corners
-    @assert UL.eV == UR.eV "UL and UR must have the same eV value"
-    @assert LL.eV == LR.eV "LL and LR must have the same eV value"
+    @assert UL.eV == UR.eV "UL and UR must have the same eV value  (UL, UR, LL, LR)"
+    @assert LL.eV == LR.eV "LL and LR must have the same eV value  (UL, UR, LL, LR)"
     step_phi = _step(dims(A, :phi))
     L_rect, R_rect = if isnothing(base_corners)
         extrema(lookup(A, :phi))
@@ -106,8 +106,8 @@ function trapezoid(  # convert from rectangle
     @assert _is_equal_spacing(lookup(A, :phi)) "A must be equally spaced along :phi dimension"
     L_rect, R_rect = base_corners
     UL, UR, LL, LR = trapezoid_corners
-    @assert UL.eV == UR.eV "UL and UR must have the same eV value"
-    @assert LL.eV == LR.eV "LL and LR must have the same eV value"
+    @assert UL.eV == UR.eV "UL and UR must have the same eV value  (UL, UR, LL, LR)"
+    @assert LL.eV == LR.eV "LL and LR must have the same eV value  (UL, UR, LL, LR)"
     step_phi = _step(dims(A, :phi))
 
     @assert L_rect < R_rect "L_Rect must be less than R_Rect"
@@ -131,6 +131,7 @@ function trapezoid(  # convert from rectangle
     @debug "max_to_phi: $max_to_phi, min_to_phi: $min_to_phi"
 
     to_phi_range = range(start = min_to_phi, step = abs(step_phi), stop = max_to_phi)
+    @debug "to_phi_range" length(to_phi_range) extrema(to_phi_range)
     to_phi_grid, ek_grid = prepare_for_broadcast(to_phi_range, parent(lookup(A, :eV)))
     from_phi_grid = _phi_to_phi(to_phi_grid, ek_grid, trapezoid_corners, (L_rect, R_rect))
     data_transposed = _interpolate(
@@ -140,11 +141,41 @@ function trapezoid(  # convert from rectangle
         parent(lookup(A, :eV)),
         parent(A),
     )
+
+    @debug "trapezoid output check" size(data_transposed) length(to_phi_range)
     new_phi_dim = Dim{:phi}(to_phi_range; metadata = metadata(dims(A, :phi)))
     new_dims = Base.setindex(dims(A), new_phi_dim, dimnum(A, :phi))
+
     return rebuild(A; data = data_transposed, dims = new_dims)
 end
 
+function trapezoid(
+    A::ARPESData{T,2} where {T},
+    base_corners::Tuple{Real,Real},
+    trapezoid_corners::NTuple{4,NamedTuple{(:phi, :eV),Tuple{Float64,Float64}}},  # (UL, UR, LL, LR)
+)
+    reorddered_corners = (
+        (eV = trapezoid_corners[1].eV, phi = trapezoid_corners[1].phi),
+        (eV = trapezoid_corners[2].eV, phi = trapezoid_corners[2].phi),
+        (eV = trapezoid_corners[3].eV, phi = trapezoid_corners[3].phi),
+        (eV = trapezoid_corners[4].eV, phi = trapezoid_corners[4].phi),
+    )
+    return trapezoid(A, base_corners, reorddered_corners)
+end
+
+function trapezoid(
+    A::ARPESData{T,2} where {T},
+    trapezoid_corners::NTuple{4,NamedTuple{(:phi, :eV),Tuple{Float64,Float64}}},  # (UL, UR, LL, LR)
+    base_corners::Tuple{Real,Real},
+)
+    reorddered_corners = (
+        (eV = trapezoid_corners[1].eV, phi = trapezoid_corners[1].phi),
+        (eV = trapezoid_corners[2].eV, phi = trapezoid_corners[2].phi),
+        (eV = trapezoid_corners[3].eV, phi = trapezoid_corners[3].phi),
+        (eV = trapezoid_corners[4].eV, phi = trapezoid_corners[4].phi),
+    )
+    return trapezoid(A, reorddered_corners, base_corners)
+end
 
 """
     _phi_to_phi(p, Ek, trapezoid_corners, base_corners)   # rectangle => trapezoid


### PR DESCRIPTION
This pull request introduces a mix of bug fixes, improved debugging, and API enhancements across several modules, primarily focusing on the trapezoid transformation logic, range generation, and dimension handling. The most important changes are summarized below:

### Trapezoid Transformation Improvements

* Improved input validation and error messages in the `trapezoid` function to clarify which corners are being compared, and added debug statements to output the length and extrema of the resulting phi range. [[1]](diffhunk://#diff-4ddf2ed6079ca3b169a4311057014d1be768bf0922460fa860a4fca989e02b07L56-R57) [[2]](diffhunk://#diff-4ddf2ed6079ca3b169a4311057014d1be768bf0922460fa860a4fca989e02b07L109-R110) [[3]](diffhunk://#diff-4ddf2ed6079ca3b169a4311057014d1be768bf0922460fa860a4fca989e02b07R134)
* Added overloaded versions of the `trapezoid` function to support both (base_corners, trapezoid_corners) and (trapezoid_corners, base_corners) argument orders, with automatic reordering of the trapezoid corners for internal consistency.

### Range Generation and Consistency

* Changed range construction in `_deg2rad` and `_ek_range` to use the `length` parameter instead of `stop` for more robust and consistent range generation, preventing off-by-one errors. [[1]](diffhunk://#diff-695114c43edd4e5dd316b898243bdb363ab982881ec79116df0f65d5952916ebL475-R481) [[2]](diffhunk://#diff-8ec3b9c3386b86f64ac3701e5e805d1aadec499cacb5bf30952102a2b6565b1bL81-R83)
* Added debug output for the length of the generated `kx_range` in `_kx_range`, aiding in troubleshooting and validation of the output.

### Debugging and Validation

* Added multiple debug statements throughout the codebase (e.g., in `negate_dim`, `k_conversion`, and trapezoid transformation functions) to trace the state of key variables and array sizes, making it easier to diagnose issues during development. [[1]](diffhunk://#diff-bac3a24ba0b1ebd71050d2b00b1b51a842023eb5f61d8198126c974cdc000c69R272-R280) [[2]](diffhunk://#diff-695114c43edd4e5dd316b898243bdb363ab982881ec79116df0f65d5952916ebR95-R104) [[3]](diffhunk://#diff-4ddf2ed6079ca3b169a4311057014d1be768bf0922460fa860a4fca989e02b07R134) [[4]](diffhunk://#diff-4ddf2ed6079ca3b169a4311057014d1be768bf0922460fa860a4fca989e02b07R144-R178)
* Fixed a bug in `_check_arpesdata` where dimension symbols were not quoted, ensuring the function checks for the correct dimension names.

### Documentation

* Clarified the documentation for `trapezoid_corners` to specify the expected order and structure of the input, reducing ambiguity for users.