### PR TITLE
Tarpes evolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.3
+## [0.2.3] — Unreleased
+
+### Added
+
+- `tarpes_evolution` (src/pumpprobe.jl): helper to extract a 2D snapshot and the temporal evolution from 3D time-resolved ARPES datasets. Supports selection by delay time or delay index, scalar or (center, width) averaging along the non-dispersion axis, and a `full_temporal` flag to include the full time range. Unit tests added in `test/pumpprobe.jl`.
+
+### Changed
+
+- 
+
+### Fixed
+
+- 
+
 
 ## [0.2.2] — 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.3
+
 ## [0.2.2] — 2026-04-16
 
 ### Added

--- a/src/pumpprobe.jl
+++ b/src/pumpprobe.jl
@@ -1,4 +1,101 @@
+using DimensionalData
+using Statistics
+
 export delaytime_fs, position_mm_to_delaytime_fs
+export tarpes_evolution
 
 delaytime_fs(mirror_move_μm::Real) = 3.335640951981521 * mirror_move_μm
 position_mm_to_delaytime_fs(position_mm::Real) = delaytime_fs(2 * position_mm * 1e3)
+
+"""
+    tarpes_evolution(A, delay_time=0.0, evolution_at=0.0; stack_dim=:delay, vertical_dim=:eV)
+    tarpes_evolution(A, delay_index::Integer, evolution_at=0.0; ...)
+
+Return a snapshot and the temporal evolution extracted from a 3D time-resolved ARPES dataset.
+
+Arguments
+- A::AbstractDimArray{T,3}: 3D tr-ARPES data with named dimensions (DimensionalData).
+- delay_time::Real: Delay time (same units as the `stack_dim`) for the snapshot. Alternatively use delay_index.
+- evolution_at::Real or Tuple{center, width}: If a scalar, select the nearest coordinate along the non-dispersion axis. If a (center, width) tuple, average over the window centered at `center` with the given `width`.
+- stack_dim::Symbol: Name of the time/delay dimension (default :delay).
+- vertical_dim::Symbol: Name of the vertical (energy) dimension (default :eV).
+- full_temporal::Bool: If true, include the full time range for the temporal evolution; otherwise include only times <= `delay_time`.
+
+Returns
+- arpes_data_at_delay::AbstractDimArray{T,2}: 2D slice (non-dispersion × vertical) at the chosen delay.
+- temporal_evolution_data::AbstractDimArray{T,2}: 2D array (time × vertical) with intensity evolution at the selected non-dispersion position(s).
+
+Notes
+- Selection uses DimensionalData indexing (Dim{...}(Near/Between)).
+"""
+function tarpes_evolution(
+    A::AbstractDimArray{T,3} where {T},
+    delay_time::Real = 0.0,
+    evolution_at::Union{Real,Tuple{<:Real,<:Real}} = 0.0;
+    stack_dim::Symbol = :delay,
+    vertical_dim::Symbol = :eV,
+    full_temporal::Bool = false,
+)
+
+    non_dispersion_axis = otherdims(A, (vertical_dim, stack_dim)) |> first |> name
+    arpes_data_at_delay = A[Dim{stack_dim}(Near(delay_time))]
+
+    temporal_evolution_data =
+        _build_slice_data(A, non_dispersion_axis, evolution_at) |>
+        x->permutedims(x, (stack_dim, vertical_dim)) |>
+           x -> x[Dim{stack_dim}(Between(-Inf, full_temporal ? Inf : delay_time))]
+
+    return arpes_data_at_delay, temporal_evolution_data
+end
+
+function tarpes_evolution(
+    A::AbstractDimArray{T,3} where {T},
+    delay_index::Integer,
+    evolution_at::Union{Real,Tuple{<:Real,<:Real}} = 0.0;
+    stack_dim::Symbol = :delay,
+    vertical_dim::Symbol = :eV,
+    full_temporal::Bool = false,
+)
+    delay_time = dims(A, stack_dim)[delay_index] |> float
+    return tarpes_evolution(
+        A,
+        delay_time,
+        evolution_at;
+        stack_dim = stack_dim,
+        vertical_dim = vertical_dim,
+        full_temporal = full_temporal,
+    )
+end
+
+"""
+    _build_slice_data(A, non_dispersion_axis, evolution_at::Real)
+    _build_slice_data(A, non_dispersion_axis, evolution_at::Tuple{center,width})
+
+Internal helper. For a scalar `evolution_at`, select the nearest coordinate along
+`non_dispersion_axis`. For a `(center, width)` tuple, average A over the window
+[center - width/2, center + width/2] along `non_dispersion_axis` and drop that dimension.
+"""
+function _build_slice_data(
+    A::AbstractDimArray{T,3} where {T},
+    non_dispersion_axis::Symbol,
+    evolution_at::Real,
+)
+    return A[Dim{non_dispersion_axis}(Near(evolution_at))]
+end
+
+function _build_slice_data(
+    A::AbstractDimArray{T,3} where {T},
+    non_dispersion_axis::Symbol,
+    evolution_at::Tuple{<:Real,<:Real},
+)
+    evolution_left = evolution_at[1] - evolution_at[2]/2
+    evolution_right = evolution_at[1] + evolution_at[2]/2
+
+    sliced =
+        A[Dim{non_dispersion_axis}(Between(evolution_left, evolution_right))] |>
+        x ->
+            mean(x, dims = non_dispersion_axis) |>
+            x -> dropdims(x, dims = non_dispersion_axis)
+
+    return sliced
+end

--- a/test/pumpprobe.jl
+++ b/test/pumpprobe.jl
@@ -4,7 +4,7 @@ using DimensionalData: @dim, Dim
 using ARPES
 using ARPES: ARPESData, kx, ky, kz, phi, psi, eV, delay
 
-@testset "ARPESPlots tarpes Heatmap Tests" begin
+@testset "ARPESPlots tarpes_evolution Tests" begin
     data = rand(Float64, 40, 60, 30)
     data[3, 3, 3] = NaN
     data[1, 1, 1] = NaN

--- a/test/pumpprobe.jl
+++ b/test/pumpprobe.jl
@@ -3,6 +3,7 @@ using DimensionalData
 using DimensionalData: @dim, Dim
 using ARPES
 using ARPES: ARPESData, kx, ky, kz, phi, psi, eV, delay
+using Statistics: mean
 
 @testset "ARPESPlots tarpes_evolution Tests" begin
     data = rand(Float64, 40, 60, 30)
@@ -23,8 +24,10 @@ using ARPES: ARPESData, kx, ky, kz, phi, psi, eV, delay
     @test size(temporal, 2) == size(arpes_snapshot, 2)
 
     # delay-index variant should match the delay_time variant at the nearest index
-    nearest_idx = argmin(abs.(dims(A, :delay) .- 0.0))
+    nearest_idx = findlast(dims(A, :delay) .<= 0.0)
     arpes_snapshot_idx, temporal_idx = tarpes_evolution(A, nearest_idx, 0.0)
+    nearest_delay = dims(A, :delay)[nearest_idx] # 👈 Use actual value of delay
+    arpes_snapshot, temporal = tarpes_evolution(A, nearest_delay, 0.0)
     @test isequal(arpes_snapshot, arpes_snapshot_idx)
     @test isequal(temporal, temporal_idx)
 
@@ -37,12 +40,14 @@ using ARPES: ARPESData, kx, ky, kz, phi, psi, eV, delay
     expected =
         A[Dim{:phi}(Between(center - width/2, center + width/2))] |>
         x ->
-            dropdims(x, dims = :phi) |>
+            mean(x, dims = :phi) |>
             x ->
-                mean(x, dims = :phi) |>
-                x -> permutedims(x, (:delay, :eV)) |> x[Dim{:delay}(Between(-Inf, 0.0))]
+                dropdims(x, dims = :phi) |>
+                x ->
+                    permutedims(x, (:delay, :eV)) |> x -> x[Dim{:delay}(Between(-Inf, 0.0))]
 
     @test size(temporal_avg) == size(expected)
     @test isapprox(temporal_avg, expected; atol = 1e-12, rtol = 1e-8)
 
 end
+

--- a/test/pumpprobe.jl
+++ b/test/pumpprobe.jl
@@ -1,0 +1,48 @@
+using Test
+using DimensionalData
+using DimensionalData: @dim, Dim
+using ARPES
+using ARPES: ARPESData, kx, ky, kz, phi, psi, eV, delay
+
+@testset "ARPESPlots tarpes Heatmap Tests" begin
+    data = rand(Float64, 40, 60, 30)
+    data[3, 3, 3] = NaN
+    data[1, 1, 1] = NaN
+    A = ARPESData(
+        data,
+        (phi(range(-10, 10.0, 40)), eV(range(0, 5.0, 60)), delay(range(-3.0, 5.1, 30))),
+    )
+
+    # Basic scalar selection: snapshot shape and temporal evolution size
+    arpes_snapshot, temporal = tarpes_evolution(A, 0.0, 0.0)
+    @test size(arpes_snapshot) == (size(A, 1), size(A, 2))
+
+    delays = dims(A, :delay)
+    expected_rows = sum(delays .<= 0.0)
+    @test size(temporal, 1) == expected_rows
+    @test size(temporal, 2) == size(arpes_snapshot, 2)
+
+    # delay-index variant should match the delay_time variant at the nearest index
+    nearest_idx = argmin(abs.(dims(A, :delay) .- 0.0))
+    arpes_snapshot_idx, temporal_idx = tarpes_evolution(A, nearest_idx, 0.0)
+    @test isequal(arpes_snapshot, arpes_snapshot_idx)
+    @test isequal(temporal, temporal_idx)
+
+    # Tuple averaging along the non-dispersion axis
+    center = 0.0
+    width = 2.0
+    _, temporal_avg = tarpes_evolution(A, 0.0, (center, width))
+
+    # Build expected temporal evolution manually
+    expected =
+        A[Dim{:phi}(Between(center - width/2, center + width/2))] |>
+        x ->
+            dropdims(x, dims = :phi) |>
+            x ->
+                mean(x, dims = :phi) |>
+                x -> permutedims(x, (:delay, :eV)) |> x[Dim{:delay}(Between(-Inf, 0.0))]
+
+    @test size(temporal_avg) == size(expected)
+    @test isapprox(temporal_avg, expected; atol = 1e-12, rtol = 1e-8)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ include("./fixture.jl")
         include("derivative.jl")
         include("stitch.jl")
         include("trapezoid.jl")
+        include("pumpprobe.jl")
     end
     @testset "k_conv" begin
         include("k_conv/preprocess.jl")


### PR DESCRIPTION
This pull request introduces a new utility function for analyzing time-resolved ARPES datasets, along with corresponding documentation and tests. The main addition is the `tarpes_evolution` function, which provides a convenient and flexible way to extract snapshots and temporal evolutions from 3D tr-ARPES data. The changes also include comprehensive unit tests and an update to the changelog.

**New feature: ARPES data analysis**
- Added the `tarpes_evolution` function in `src/pumpprobe.jl` to extract 2D snapshots and temporal evolutions from 3D time-resolved ARPES datasets. This function supports flexible selection by delay time or index, averaging along the non-dispersion axis, and an option to include the full time range. Internal helpers handle both scalar and windowed averaging.

**Documentation**
- Documented the new `tarpes_evolution` function with a detailed docstring explaining its arguments, return values, and usage.
- Updated the `CHANGELOG.md` to describe the addition of `tarpes_evolution` and its capabilities.

**Testing**
- Added unit tests for `tarpes_evolution` in `test/pumpprobe.jl`, covering various usage patterns including scalar selection, tuple averaging, and comparison between delay time and delay index variants.
- Integrated the new test file into the test suite by including it in `test/runtests.jl`.