### PR TITLE
:art:

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ Run the full test suite:
 julia --project=. -e 'using Pkg; Pkg.test()'
 ```
 
+Run the full test suite with code coverage and then generage HTML coverage reepot:
+
+```bash
+julia --project=. --code-coverage=user -e 'using Pkg; Pkg.test(); Pkg.activate("test"; shared=false); using Coverage; c = process_folder(); LCOV.writefile("lcov.info", c); clean_folder(".")' && genhtml lcov.info -o coverage_html
+```
+
 Run a single test file directly from the repository root:
 
 ```bash

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,3 +67,10 @@ if isdir(testdata_dir)
         include("io/registry_testdata.jl")
     end
 end
+
+if Base.JLOptions().code_coverage > 0
+    coverage = process_folder()
+    LCOV.writefile("lcov.info", coverage)
+    clean_folder(".")
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,7 +68,7 @@ if isdir(testdata_dir)
     end
 end
 
-if Base.JLOptions().code_coverage > 0
+if Base.JLOptions().code_coverage > 0 && !haskey(ENV, "GITHUB_ACTIONS")
     coverage = process_folder()
     LCOV.writefile("lcov.info", coverage)
     clean_folder(".")


### PR DESCRIPTION
This pull request adds support for code coverage reporting to the test suite and updates the documentation to explain how to generate and view coverage reports. The main changes include new instructions in the `README.md` and code in the test runner to generate coverage data.

**Documentation updates:**
- Added instructions in `README.md` for running the test suite with code coverage enabled and generating an HTML coverage report.

**Test suite enhancements:**
- Updated `test/runtests.jl` to automatically generate a `lcov.info` file and clean up coverage data when tests are run with code coverage enabled.