### PR TITLE
:tada: (Bump up version 0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3] — Unreleased
+## [0.2.3] — 2026-08-15
 
 ### Added
 
-- `tarpes_evolution` (src/pumpprobe.jl): helper to extract a 2D snapshot and the temporal evolution from 3D time-resolved ARPES datasets. Supports selection by delay time or delay index, scalar or (center, width) averaging along the non-dispersion axis, and a `full_temporal` flag to include the full time range. Unit tests added in `test/pumpprobe.jl`.
+- `tarpes_evolution` (src/pumpprobe.jl): helper to extract a 2D snapshot and the temporal evolution from 3D time-resolved ARPES datasets.
+  - Supports selection by delay time or delay index, scalar or (center, width) averaging along the non-dispersion axis, and a `full_temporal` flag to include the full time range.
 
 ### Changed
 
@@ -18,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- src/trapezoid.jl: refactored implementation — extracted input validation (_validate_trapezoid_input, _validate_base_corners), added corner normalization (_normalize_trapezoid_corners), and reorganized rectangle⇄trapezoid coordinate mapping into _phi_to_phi_impl and _source_phi_grid. Improved output-phi range calculation (_output_phi_bounds) and interpolation-grid generation using prepare_for_broadcast. Conversion now performs linear interpolation on angular slices while preserving the eV axis. Added/updated unit tests.
+- src/trapezoid.jl: refactored implementation — extracted input validation (_validate_trapezoid_input,_validate_base_corners), added corner normalization (_normalize_trapezoid_corners), and reorganized rectangle⇄trapezoid coordinate mapping into_phi_to_phi_impl and_source_phi_grid. Improved output-phi range calculation (_output_phi_bounds) and interpolation-grid generation using prepare_for_broadcast. Conversion now performs linear interpolation on angular slices while preserving the eV axis.
 
 - Refactored src/io/formats/itx.jl and src/k_conv/preprocess.jl: reorganized ITX parsing into clearer helper functions and improved robustness of scale/waves parsing and DimArray construction; added helpers in k_conv/preprocess.jl (prepare_for_broadcast, _ek_range, _kx_range, _ky_range) and stricter ARPESData validation (_check_arpesdata) to make k-conversion preprocessing more deterministic. Corresponding tests added/updated in test/io/formats/itx.jl to cover WAVES/SetScale/comment parsing and wave data assembly (commit 36aa831).
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ARPES"
 uuid = "3764e38b-e87f-453d-b456-dc646f8e1bb8"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Ryuichi Arafune"]
 
 [deps]


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` to clarify and reformat recent changes for the upcoming 0.2.3 release. 

* Updated the release date for version 0.2.3 and reformatted the description of the new `tarpes_evolution` helper for clarity and readability.
